### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/lisp/xenops-style.el
+++ b/lisp/xenops-style.el
@@ -8,7 +8,7 @@
 ;; extension of `prettify-symbols-mode'.
 
 ;;; Code:
-(require 'dash-functional)
+(require 'dash)
 (require 's)
 
 (declare-function xenops-util-first-index "xenops-util")

--- a/lisp/xenops.el
+++ b/lisp/xenops.el
@@ -3,7 +3,7 @@
 ;; Author: Dan Davison <dandavison7@gmail.com>
 ;; URL: https://github.com/dandavison/xenops
 ;; Version: 0.0.0
-;; Package-Requires: ((emacs "26.1") (aio "1.0") (auctex "12.2.0") (avy "0.5.0") (dash "2.17.0") (dash-functional "1.2.0") (f "0.20.0") (s "1.12.0"))
+;; Package-Requires: ((emacs "26.1") (aio "1.0") (auctex "12.2.0") (avy "0.5.0") (dash "2.18.0") (f "0.20.0") (s "1.12.0"))
 
 ;; SPDX-License-Identifier: MIT
 
@@ -61,7 +61,6 @@
 (require 'aio)
 (require 'avy)
 (require 'dash)
-(require 'dash-functional)
 (require 'f)
 (require 'preview)
 (require 's)

--- a/tests/setup/install-deps.el
+++ b/tests/setup/install-deps.el
@@ -7,7 +7,6 @@
   '(aio
     avy
     dash
-    dash-functional
     f
     s
     use-package))


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218