### PR TITLE
Require dash in all files that use dash macros

### DIFF
--- a/lisp/xenops-minted.el
+++ b/lisp/xenops-minted.el
@@ -9,6 +9,7 @@
 ;; of type 'minted and 'src.
 
 ;;; Code:
+(require 'dash)
 
 (declare-function xenops-parse-element-at-point "xenops-parse")
 (declare-function xenops-util-plist-update "xenops-util")

--- a/lisp/xenops-parse.el
+++ b/lisp/xenops-parse.el
@@ -5,6 +5,7 @@
 ;;; Commentary:
 
 ;;; Code:
+(require 'dash)
 
 (declare-function xenops-elements-get "xenops-elements")
 (declare-function xenops-elements-get-all "xenops-elements")

--- a/lisp/xenops-src.el
+++ b/lisp/xenops-src.el
@@ -9,6 +9,7 @@
 ;; 'src.
 
 ;;; Code:
+(require 'dash)
 
 (declare-function xenops-dispatch-operation "xenops")
 (declare-function xenops-apply-parse-next-element "xenops-apply")

--- a/lisp/xenops-util.el
+++ b/lisp/xenops-util.el
@@ -5,6 +5,8 @@
 ;;; Commentary:
 
 ;;; Code:
+(require 'dash)
+
 (declare-function xenops-overlay-create "xenops-overlay")
 
 (defmacro xenops-util-define-key-with-fallback (key handler &optional fallback-key)


### PR DESCRIPTION
I suspect that (eval-when-compile (require 'dash)) is actually
more correct, but (require 'dash) is already used in some other
files so just doing this now until I know the correct global change
to require expressions in all package files.

Should fix #27