### PR TITLE
Fix `xenops-src-parse-at-point` for Org 9.7

### DIFF
--- a/lisp/xenops-src.el
+++ b/lisp/xenops-src.el
@@ -48,8 +48,9 @@ under some OSs / Mathematica versions.")
 (defun xenops-src-parse-at-point ()
   "Parse 'src element at point."
   (-if-let* ((element (xenops-parse-element-at-point 'src))
-             (org-element (xenops-src-do-in-org-mode (org-element-context)))
-             (org-babel-info (org-babel-get-src-block-info 'light org-element)))
+             (org-babel-info
+              (xenops-src-do-in-org-mode
+               (org-babel-get-src-block-info 'light (org-element-context)))))
       (xenops-util-plist-update
        element
        :type 'src


### PR DESCRIPTION
Fixes #73. The error seems to come from `org-element-context` containing references to the killed temp buffer created by the `xenops-src-do-in-org-mode` macro, and `org-babel-get-src-block-info` feeding those references into `with-current-buffer`. Hence this fix just includes the call to `org-babel-get-src-block-info` in the scope of the `xenops-src-do-in-org-mode` macro.

As I do not use xenops-mode myself, and thus do not know the expected behaviour, it is not very well tested.