### PR TITLE
Preserve window configuration in `xenops-do-src-in-org-mode`

### DIFF
--- a/lisp/xenops-src.el
+++ b/lisp/xenops-src.el
@@ -31,19 +31,20 @@ under some OSs / Mathematica versions.")
 
 (defmacro xenops-src-do-in-org-mode (&rest body)
   "Execute forms in BODY with current src block in an Org mode buffer."
-  `(save-restriction
-     (progn
-       (condition-case nil
-           (org-narrow-to-block)
-         (user-error nil))
-       (let ((region (buffer-substring (point-min) (point-max))))
-         (with-temp-buffer
-           (erase-buffer)
-           (insert xenops-src-do-in-org-mode-header)
-           (insert region)
-           (let ((org-mode-hook))
-             (org-mode))
-           ,@body)))))
+  `(save-window-excursion
+     (save-restriction
+       (progn
+         (condition-case nil
+             (org-narrow-to-block)
+           (user-error nil))
+         (let ((region (buffer-substring (point-min) (point-max))))
+           (with-temp-buffer
+             (erase-buffer)
+             (insert xenops-src-do-in-org-mode-header)
+             (insert region)
+             (let ((org-mode-hook))
+               (org-mode))
+             ,@body))))))
 
 (defun xenops-src-parse-at-point ()
   "Parse 'src element at point."


### PR DESCRIPTION
As the current buffer gets narrowed in the macro, this can change the `window-start` position. In particular, it scrolls the buffer such that the current src block is at the top of the window. This side effect might be undesirable (but feel free to disregard this if it is intended, or for any other reason). Hence we prevent it with `save-window-excursion`.